### PR TITLE
replace sha1 with sha256

### DIFF
--- a/crypt/crypt.go
+++ b/crypt/crypt.go
@@ -5,7 +5,6 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/x509"
 	"fmt"
@@ -90,7 +89,7 @@ func (pk *PrivKey) Decrypt(pub *PubKey, encryptedData []byte) ([]byte, error) {
 	}
 
 	encryptedPass := encryptedData[:encryptedPassLen]
-	decryptedPass, err := rsa.DecryptOAEP(sha1.New(), rand.Reader, pk.priv, encryptedPass, nil)
+	decryptedPass, err := rsa.DecryptOAEP(sha256.New(), rand.Reader, pk.priv, encryptedPass, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed decrypt pass")
 	}
@@ -191,7 +190,7 @@ func (pk *PubKey) Encrypt(priv *PrivKey, decrypted []byte) ([]byte, error) {
 	decryptedPass := hash // use the hash of the msg as its pass
 	encryptedData := enc(decryptedPass, nonce, decrypted)
 
-	encryptedPass, err := rsa.EncryptOAEP(sha1.New(), rand.Reader, pk.pub, decryptedPass, nil)
+	encryptedPass, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, pk.pub, decryptedPass, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to _go2p_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](https://github.com/v-braun/go2p/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe how you tested your changes. --->
<!-- If you are submitting a link to your app for the README, you can omit this section. -->
In crypt/crypt.go, the `Encrypt` and `Decrypt` functions use SHA-1 as the hash algorithms, which is insecure now because of the collisions. See [_Finding Collisions in the Full SHA-1_](https://www.iacr.org/archive/crypto2005/36210017/36210017.pdf)
In order to avoid potential attacks, I suggest we replace all SHA-1 uses with SHA-256, which is a recommended algorithm for key management.

### Description
<!--- Describe your changes in detail. -->

1. replace all SHA-1 algorithm uses with SHA-256 algorithm.
2. remove the "crypto/sha1" import